### PR TITLE
Feat: OCI Client Config 파일 프로젝트내로 이동

### DIFF
--- a/src/main/resources/application_dev.yml
+++ b/src/main/resources/application_dev.yml
@@ -43,5 +43,5 @@ cloud:
     bucket: tripbook
     namespace: axxqmwxdbwz5
     preAuthenticatedUrl: https://objectstorage.ap-chuncheon-1.oraclecloud.com/p/ea-1Bvx4xgjJafTXZT20GQPP-hjf6GWTgJ3O2qOmkNP89dxvn-aakbnwVpbWtnE_/n/axxqmwxdbwz5/b/tripbook/o/
-    configFilePath: ~/ocikey/config
+    configFilePath: src/main/resources/config
 ---

--- a/src/main/resources/application_local.yml
+++ b/src/main/resources/application_local.yml
@@ -44,5 +44,5 @@ cloud:
     bucket: tripbook
     namespace: axxqmwxdbwz5
     preAuthenticatedUrl: https://objectstorage.ap-chuncheon-1.oraclecloud.com/p/ea-1Bvx4xgjJafTXZT20GQPP-hjf6GWTgJ3O2qOmkNP89dxvn-aakbnwVpbWtnE_/n/axxqmwxdbwz5/b/tripbook/o/
-    configFilePath: ~/ocikey/config
+    configFilePath: src/main/resources/config
 ---

--- a/src/main/resources/config
+++ b/src/main/resources/config
@@ -1,0 +1,6 @@
+[DEFAULT]
+user=ocid1.user.oc1..aaaaaaaaype3ilyygukqwrv726pagf2tfallv23ruhzglsriahfjpjdqbuiq
+fingerprint=25:2c:22:17:1f:d2:80:a4:a7:7b:03:f9:a4:ca:f6:d2
+tenancy=ocid1.tenancy.oc1..aaaaaaaam5op3yju4zludnaq6a5kh4olvxubrn2jdzjhubfbpflmuexk2u5a
+region=ap-chuncheon-1
+key_file=~/ocikey/oci_api_key.pem


### PR DESCRIPTION
## 요약
- 각자 로컬에서 관리하던 Config 파일을 프로젝트 내로 이동

## 변경점
- `src/main/resources/` 경로에 config 파일 추가
- yml 파일 내의 `cloud.oci.configFilePath` 변경

## 참고사항
- `oci_api-key.pem` 파일은 로컬 `~/ocikey/` 경로에 존재해야 합니다.

## 이슈사항
