### PR TITLE
Fix: DB 변경으로인한 관련 설정 수정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,26 @@
             <artifactId>oci-java-sdk-objectstorage</artifactId>
             <version>3.15.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.security</groupId>
+            <artifactId>osdt_cert</artifactId>
+            <version>21.3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.security</groupId>
+            <artifactId>oraclepki</artifactId>
+            <version>21.3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.security</groupId>
+            <artifactId>osdt_core</artifactId>
+            <version>21.3.0.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/application_dev.yml
+++ b/src/main/resources/application_dev.yml
@@ -19,8 +19,9 @@ spring:
               sql: trace
 
   datasource:
-    url: jdbc:mysql://tripbook-dev.czriggtksvqu.ap-northeast-2.rds.amazonaws.com:3306/tripbook_main?createDatabaseIfNotExist=true
-    username: tripbook
+    driver-class-name: oracle.jdbc.OracleDriver
+    url: jdbc:oracle:thin:@(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1522)(host=adb.ap-chuncheon-1.oraclecloud.com))(connect_data=(service_name=g0c683083de637b_tripbookdev_tp.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))
+    username: ADMIN
     password: Tripbookteam07*
   security:
     oauth2:

--- a/src/main/resources/application_local.yml
+++ b/src/main/resources/application_local.yml
@@ -18,8 +18,9 @@ spring:
               sql: trace
 
   datasource:
-    url: jdbc:mysql://tripbook-dev.czriggtksvqu.ap-northeast-2.rds.amazonaws.com:3306/tripbook_main?createDatabaseIfNotExist=true
-    username: tripbook
+    driver-class-name: oracle.jdbc.OracleDriver
+    url: jdbc:oracle:thin:@(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1522)(host=adb.ap-chuncheon-1.oraclecloud.com))(connect_data=(service_name=g0c683083de637b_tripbookdev_tp.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))
+    username: ADMIN
     password: Tripbookteam07*
   security:
     oauth2:


### PR DESCRIPTION
## 요약
- OCI에서 ORACLE DB만 무료옵션을 제공하여 ORACLE로 DB 변경 

## 변경점
- 관련 의존성 추가
- yml파일 `spring.datasource` 수정

## 참고사항
- ~~DB 접근을 위해 본인 IP를 OCI ATP의 ACL에 등록해야합니다.
  관련 사항은 백엔드 노션에 작성해 두도록 하겠습니다.~~
