### PR TITLE
Feat: 로컬환경에 H2 DB 설정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,11 @@
             <artifactId>osdt_core</artifactId>
             <version>21.3.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/tripbook/main/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/tripbook/main/security/config/WebSecurityConfig.java
@@ -42,6 +42,8 @@ public class WebSecurityConfig {
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http.headers().frameOptions().disable();
+
 		//PlatForm 토큰 인증필터
 		http
 			.authorizeHttpRequests()
@@ -50,6 +52,7 @@ public class WebSecurityConfig {
 			.addFilterBefore(oAuth2AccessTokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 		http
 			.authorizeHttpRequests()
+			.requestMatchers("/h2-console/**").permitAll()
 			.requestMatchers(HttpMethod.POST, "/member/signup")
 			.permitAll()
 			.requestMatchers(HttpMethod.POST, "/member/**")

--- a/src/main/resources/application_local.yml
+++ b/src/main/resources/application_local.yml
@@ -16,12 +16,14 @@ spring:
           type:
             descriptor:
               sql: trace
-
+  h2:
+    console:
+      enabled: true
   datasource:
-    driver-class-name: oracle.jdbc.OracleDriver
-    url: jdbc:oracle:thin:@(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1522)(host=adb.ap-chuncheon-1.oraclecloud.com))(connect_data=(service_name=g0c683083de637b_tripbookdev_tp.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))
-    username: ADMIN
-    password: Tripbookteam07*
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:tripbook
+    username: sa
+    password:
   security:
     oauth2:
       client:


### PR DESCRIPTION
## 요약
- 로컬환경에서 H2를 이용하도록 설정

## 변경 사항
- `application_local.yml` > `spring.datasourse` : `Oracle` > `H2`
- `WebSecurityConfig` : h2를 사용할 수 있도록 인증 및 보안 설정

## 참고 사항
- 접속 : `localhost:8080/h2-console
- 연결 정보
  - jdbc url : `jdbc:h2:mem:tripbook`
  - username : sa
  - password: 