### PR TITLE
Fix: 파일 업로드 최대 용량 제한 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,9 @@ jwt:
   secret: 32543a4271369f9b539d9824b98ba055629a69f6f278a24cd6f36a63d0fc282986965bcb0a56cf9d1b2cb50c9c91003a5982c3db9d60d58c205e3373aa0bae68
 # default
 spring:
+  servlet:
+    multipart:
+      max-file-size: 5MB
   profiles:
     active: local
 ---


### PR DESCRIPTION
## 요약
- 파일 업로드 최대 용량 제한 수정

## 변경사항
- 최대 용량 1MB(default) > 5MB

## 에러내용
org.springframework.web.multipart.MaxUploadSizeExceededException: Maximum upload size exceeded

Caused by: org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException: The field photo exceeds its maximum permitted size of 1048576 bytes