### PR TITLE
featrue-SpringDevetools 의존성추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,12 @@
         <java.version>17</java.version>
     </properties>
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-devtools -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <version>3.1.2</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-aws -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
# 추가사항
- Spring Dev Tools 라이브러리를 추가하였습니다.
  - 참고 사이트 [URL](https://velog.io/@bread_dd/Spring-Boot-Devtools)

# 추가이유
- 개발환경의 In-Memory DB Console 사용을 위함(H2)