### PR TITLE
fix: 타겟 브랜치 이름이 잘못된 부분 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to Amazon EC2
 on:
   push:
     branches:
-      - develops
+      - develop
 
 # 본인이 설정한 값을 여기서 채워넣습니다.
 # 리전, 버킷 이름, CodeDeploy 앱 이름, CodeDeploy 배포 그룹 이름
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build with Maven
         run: mvn -B package --file pom.xml
-        
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
## 요약
- 타겟 브랜치 이름을 `develop`으로 수정 했습니다.

## 변경점
- 이전에 타겟 브랜치 이름이 `develops`로 잘못 되어 있던 부분을 수정 했습니다.

## 참고사항
- 깃헙 액션 실행 시 서버 롤백에 대한 대응이 필요합니다.

## 이슈사항
- 이슈가 있는 경우 해당 이슈 번호와 함께 내용을 정리합니다.