### PR TITLE
Fix-OCI종속성제거

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,28 +132,6 @@
             <version>1.18.24</version>
             <scope>provided</scope>
         </dependency>
-
-        <dependency>
-            <groupId>com.oracle.oci.sdk</groupId>
-            <artifactId>oci-java-sdk-artifacts</artifactId>
-            <version>3.15.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.oracle.oci.sdk</groupId>
-            <artifactId>oci-java-sdk-common</artifactId>
-            <version>3.15.0</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/com.oracle.oci.sdk/oci-java-sdk-shaded-full -->
-        <dependency>
-            <groupId>com.oracle.oci.sdk</groupId>
-            <artifactId>oci-java-sdk-shaded-full</artifactId>
-            <version>3.15.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.oracle.oci.sdk</groupId>
-            <artifactId>oci-java-sdk-objectstorage</artifactId>
-            <version>3.15.0</version>
-        </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>


### PR DESCRIPTION
## 요약 
-  깃허브액션 사용간에 발생한 OCI 종속성 이슈 제거
## 변경점
- OCI 미사용 이유로 디펜던시를 제거하였습니다.

## 참고사항
- 해당 이슈사항 확인
  - https://github.com/tripbook2023/tripbook-main-api/actions/runs/5784497801/job/15675296090
